### PR TITLE
Change package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "gearhead/login",
+  "name": "gearhead/wp-login",
   "type": "library",
   "authors": [
     {


### PR DESCRIPTION
In order to include the package as `gearhead/wp-login`, this commit
updates the package name in the composer file.